### PR TITLE
Update footer.svelte to show 2024

### DIFF
--- a/src/lib/components/footer.svelte
+++ b/src/lib/components/footer.svelte
@@ -1,5 +1,5 @@
 <footer>
-    <p>Copyright © 2023 Meteor Development</p>
+    <p>Copyright © 2024 Meteor Development</p>
     <p>All Rights Reserved.</p>
 </footer>
 


### PR DESCRIPTION
Showing 2024 instead of 2023, fixing https://github.com/MeteorDevelopment/meteor-website/issues/29