### PR TITLE
The icon profile does not load properly after login

### DIFF
--- a/src/lib/components/navbar.svelte
+++ b/src/lib/components/navbar.svelte
@@ -69,7 +69,7 @@
             {#if $user}
                 <a class="user" href="/account">
                     <p>{$user.username}</p>
-                    <img src={$user.discordAvatar ? $user.discordAvatar : "/empty-profile.png"} alt="profile"/>
+                    <img src={$user.discordAvatar ? $user.discordAvatar : "/empty-profile.jpg"} alt="profile"/>
                 </a>
             {:else}
                 <a href="/login"><button>Login</button></a>


### PR DESCRIPTION
The icon profile does not load properly. I found the bug in code with wrong image extension. It should be jpg , not png.

Problem: 
<img width="1424" alt="image" src="https://github.com/user-attachments/assets/ebed77c1-2c36-46a0-b506-62986745ca81">

Code:

<img width="1310" alt="image" src="https://github.com/user-attachments/assets/10c79dc2-2af3-462f-941c-e52a025d43ae">
