### PR TITLE
Fix Markdown Formatting for Emphasis in Swarm FAQ

### DIFF
--- a/src/routes/faq/swarm/+page.md
+++ b/src/routes/faq/swarm/+page.md
@@ -28,5 +28,5 @@ Repeat this for any other worker accounts you want to add to your Swarm session.
 
 ## Controlling workers
 
-To control workers, just use the `.swarm` command from the host instance, this will transmit any commands you enter to *
-*all** of the workers connected to your session.
+To control workers, just use the `.swarm` command from the host instance, this will transmit any commands you enter to
+**all** of the workers connected to your session.


### PR DESCRIPTION
Fixed the Markdown formatting in the Swarm FAQ to correctly emphasize the word "all" in the sentence "this will transmit any commands you enter to **all** of the workers connected to your session." The asterisks were not properly formatted for emphasis.

Yes, that's right, I can't live without this massive change.