### PR TITLE
Fix `/forgotPassword` endpoint not working

### DIFF
--- a/src/routes/forgotPassword/+page.svelte
+++ b/src/routes/forgotPassword/+page.svelte
@@ -19,7 +19,7 @@
     }
 
     $effect(() => {
-        if (browser && !$token) goto("/account")
+        if (browser && $token) goto("/account")
     })
 </script>
 


### PR DESCRIPTION
Silly mistake in the Svelte 5 porting, added an `!` on the token check, which would fail instantly