### PR TITLE
refactor: ESLint cleanup and deprecated OTP component replacement

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM node:24-alpine AS build
 WORKDIR /app
 
 COPY package.json package-lock.json ./
-RUN npm install --legacy-peer-deps
+RUN npm install
 
 COPY . .
 RUN npm run build

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -1,91 +1,86 @@
-import tsESLint from "@typescript-eslint/eslint-plugin"
-import tsParser from "@typescript-eslint/parser"
+import js from "@eslint/js"
+import globals from "globals"
+import tsESLint from "typescript-eslint"
+import stylistic from "@stylistic/eslint-plugin"
 import svelte from "eslint-plugin-svelte"
 import svelteParser from "svelte-eslint-parser"
-import stylistic from "@stylistic/eslint-plugin"
-import globals from "globals"
+import { defineConfig } from "eslint/config"
 
-const unusedVarsConfig = {
-    args: "all",
-    argsIgnorePattern: "^_",
-    caughtErrors: "all",
-    caughtErrorsIgnorePattern: "^_",
-    destructuredArrayIgnorePattern: "^_",
-    varsIgnorePattern: "^_",
-    ignoreRestSiblings: true,
-}
-
-export default [
-    // Stylistic
-    stylistic.configs.customize({
-        indent: 4,
-        quotes: "double",
-        semi: false,
-        jsx: false,
-    }),
+export default defineConfig([
+    // ------------------------------------------------------------------------
+    // 1. Ignore build folders
+    // ------------------------------------------------------------------------
     {
+        ignores: [
+            "node_modules/**",
+            "build/**",
+            ".svelte-kit/**",
+        ],
+    },
+
+    // ------------------------------------------------------------------------
+    // 2. Base recommended configs FIRST
+    // ------------------------------------------------------------------------
+    js.configs.recommended,
+    ...tsESLint.configs.recommended,
+    ...svelte.configs.recommended,
+
+    // ------------------------------------------------------------------------
+    // 3. TypeScript files
+    // ------------------------------------------------------------------------
+    {
+        files: ["**/*.{js,mjs,cjs,ts,mts,cts}"],
+        languageOptions: {
+            parser: tsESLint.parser,
+            globals: globals.browser,
+        },
         plugins: {
             "@stylistic": stylistic,
         },
-        rules: {
-            "@stylistic/object-curly-spacing": ["error", "always"],
-            "@stylistic/brace-style": ["error", "1tbs", { allowSingleLine: true }],
-        },
     },
 
-    // TypeScript
-    {
-        files: ["**/*.ts", "**/*.tsx"],
-        languageOptions: {
-            parser: tsParser,
-            globals: {
-                ...globals.browser,
-                ...globals.node,
-            },
-        },
-        plugins: {
-            "@typescript-eslint": tsESLint,
-        },
-        rules: {
-            ...tsESLint.configs.recommended.rules,
-            "@typescript-eslint/no-unused-vars": ["error", unusedVarsConfig],
-            "@typescript-eslint/no-explicit-any": "warn",
-        },
-    },
-
-    // Svelte
-    ...svelte.configs.recommended,
+    // ------------------------------------------------------------------------
+    // 4. Svelte files
+    // ------------------------------------------------------------------------
     {
         files: ["**/*.svelte"],
         languageOptions: {
             parser: svelteParser,
             parserOptions: {
-                parser: tsParser,
+                parser: tsESLint.parser,
+                extraFileExtensions: [".svelte"],
             },
-            globals: {
-                ...globals.browser,
-            },
-        },
-        plugins: {
-            svelte,
-            "@typescript-eslint": tsESLint,
-        },
-        rules: {
-            "svelte/no-dom-manipulating": "warn",
-            "svelte/require-each-key": "warn",
-            "svelte/css-unused-selector": "off",
-            "svelte/no-unused-svelte-ignore": "off",
-            "@typescript-eslint/no-unused-vars": ["error", unusedVarsConfig],
-            "@typescript-eslint/no-explicit-any": "warn",
+            globals: globals.browser,
         },
     },
 
+    // ------------------------------------------------------------------------
+    // 5. Shared stylistic + rules
+    // ------------------------------------------------------------------------
     {
-        // Ignore generated files
-        ignores: [
-            ".svelte-kit/**",
-            "node_modules/**",
-            "build/**",
-        ],
+        files: ["**/*.{js,mjs,cjs,ts,mts,cts,svelte}"],
+        plugins: {
+            "@stylistic": stylistic,
+        },
+        rules: {
+            ...stylistic.configs.customize({
+                indent: 4,
+                quotes: "double",
+                semi: false,
+                jsx: false,
+            }).rules,
+            "@stylistic/object-curly-spacing": ["error", "always"],
+            "@stylistic/brace-style": ["error", "1tbs", { allowSingleLine: true }],
+
+            "@typescript-eslint/no-unused-vars": ["warn", {
+                args: "all",
+                argsIgnorePattern: "^_",
+                caughtErrors: "all",
+                caughtErrorsIgnorePattern: "^_",
+                destructuredArrayIgnorePattern: "^_",
+                varsIgnorePattern: "^_",
+                ignoreRestSiblings: true,
+            }],
+        },
     },
-]
+])

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "name": "meteor-site",
       "version": "0.0.1",
       "devDependencies": {
-        "@jimmyverburgt/svelte-input-otp": "^0.0.3",
         "@paypal/paypal-js": "^8.2.0",
         "@stylistic/eslint-plugin": "^5.2.0",
         "@sveltejs/adapter-node": "^5.2.13",
@@ -20,6 +19,7 @@
         "@types/unist": "^3.0.3",
         "@typescript-eslint/eslint-plugin": "^8.37.0",
         "@typescript-eslint/parser": "^8.37.0",
+        "bits-ui": "^2.14.4",
         "eslint": "^9.31.0",
         "eslint-plugin-svelte": "^3.10.1",
         "globals": "^16.3.0",
@@ -710,6 +710,34 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.3.tgz",
+      "integrity": "sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.10"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.4.tgz",
+      "integrity": "sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.3",
+        "@floating-ui/utils": "^0.2.10"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
+      "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -776,14 +804,15 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
-    "node_modules/@jimmyverburgt/svelte-input-otp": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/@jimmyverburgt/svelte-input-otp/-/svelte-input-otp-0.0.3.tgz",
-      "integrity": "sha512-+TIG8l1W6CuZcfz22hSzQP+C2O+OXLw/hUVsB3Ab+9LHb11ew6jAGmhkXMzMe2XBoipBoy5Wv1ZeOadGsfbgkQ==",
+    "node_modules/@internationalized/date": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.10.0.tgz",
+      "integrity": "sha512-oxDR/NTEJ1k+UFVQElaNIk65E/Z83HK1z1WI3lQyhTtnNg4R5oVXaPzK3jcpKG8UHKDVuDQHzn+wsxSz8RP3aw==",
       "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "svelte": "^4.0.0"
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -1309,6 +1338,7 @@
       "integrity": "sha512-6aCsU6PwxB4CQBJEvLnOoSv8hoviZWDVTKDTzQoERG6vpIHeXJufVWQlyaOXrdSlqBiwknHm0nQT/S/Nn3518A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@sveltejs/acorn-typescript": "^1.0.5",
         "@types/cookie": "^0.6.0",
@@ -1341,6 +1371,7 @@
       "integrity": "sha512-Y1Cs7hhTc+a5E9Va/xwKlAJoariQyHY+5zBgCZg4PFWNYQ1nMN9sjK1zhw1gK69DuqVP++sht/1GZg1aRwmAXQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@sveltejs/vite-plugin-svelte-inspector": "^4.0.1",
         "debug": "^4.4.1",
@@ -1373,6 +1404,16 @@
         "@sveltejs/vite-plugin-svelte": "^5.0.0",
         "svelte": "^5.0.0",
         "vite": "^6.0.0"
+      }
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.17.tgz",
+      "integrity": "sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/@types/cookie": {
@@ -1412,6 +1453,7 @@
       "integrity": "sha512-4zXMWD91vBLGRtHK3YbIoFMia+1nqEz72coM42C5ETjnNCa/heoj7NT1G67iAfOqMmcfhuCZ4uNpyz8EjlAejw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.8.0"
       }
@@ -1483,6 +1525,7 @@
       "integrity": "sha512-lJi3PfxVmo0AkEY93ecfN+r8SofEqZNGByvHAI3GBLrvt1Cw6H5k1IM02nSzu0RfUafr2EvFSw0wAsZgubNplQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.47.0",
         "@typescript-eslint/types": "8.47.0",
@@ -1675,6 +1718,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1787,6 +1831,31 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/bits-ui": {
+      "version": "2.14.4",
+      "resolved": "https://registry.npmjs.org/bits-ui/-/bits-ui-2.14.4.tgz",
+      "integrity": "sha512-W6kenhnbd/YVvur+DKkaVJ6GldE53eLewur5AhUCqslYQ0vjZr8eWlOfwZnMiPB+PF5HMVqf61vXBvmyrAmPWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.1",
+        "@floating-ui/dom": "^1.7.1",
+        "esm-env": "^1.1.2",
+        "runed": "^0.35.1",
+        "svelte-toolbelt": "^0.10.6",
+        "tabbable": "^6.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/huntabyte"
+      },
+      "peerDependencies": {
+        "@internationalized/date": "^3.8.1",
+        "svelte": "^5.33.0"
+      }
     },
     "node_modules/brace-expansion": {
       "version": "2.0.2",
@@ -2005,6 +2074,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/devalue": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.1.1.tgz",
@@ -2093,6 +2172,7 @@
       "integrity": "sha512-QldCVh/ztyKJJZLr4jXNUByx3gR+TDYZCRXEktiZoUR3PGy4qCmSbkxcIle8GEwGpb5JBZazlaJ/CxLidXdEbQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2628,6 +2708,13 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-core-module": {
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
@@ -2720,6 +2807,7 @@
       "integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -2965,6 +3053,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
       }
     },
     "node_modules/magic-string": {
@@ -3345,6 +3443,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -3644,6 +3743,7 @@
       "integrity": "sha512-4iya7Jb76fVpQyLoiVpzUrsjQ12r3dM7fIVz+4NwoYvZOShknRmiv+iu9CClZml5ZLGb0XMcYLutK6w9tgxHDw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -3700,6 +3800,31 @@
       "license": "MIT",
       "dependencies": {
         "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/runed": {
+      "version": "0.35.1",
+      "resolved": "https://registry.npmjs.org/runed/-/runed-0.35.1.tgz",
+      "integrity": "sha512-2F4Q/FZzbeJTFdIS/PuOoPRSm92sA2LhzTnv6FXhCoENb3huf5+fDuNOg1LNvGOouy3u/225qxmuJvcV3IZK5Q==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/huntabyte",
+        "https://github.com/sponsors/tglide"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "esm-env": "^1.0.0",
+        "lz-string": "^1.5.0"
+      },
+      "peerDependencies": {
+        "@sveltejs/kit": "^2.21.0",
+        "svelte": "^5.7.0"
+      },
+      "peerDependenciesMeta": {
+        "@sveltejs/kit": {
+          "optional": true
+        }
       }
     },
     "node_modules/sade": {
@@ -3883,6 +4008,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/style-to-object": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.7"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -3915,6 +4050,7 @@
       "integrity": "sha512-yHthOlJZkB4zRS41JgUSdqpytw88UVr/txXcQKLy0QKwG0HVYP6VDgOEDUWlfTOlA5oYgAcjmk4TtjDuzoQliQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.3.0",
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -4020,6 +4156,27 @@
         }
       }
     },
+    "node_modules/svelte-toolbelt": {
+      "version": "0.10.6",
+      "resolved": "https://registry.npmjs.org/svelte-toolbelt/-/svelte-toolbelt-0.10.6.tgz",
+      "integrity": "sha512-YWuX+RE+CnWYx09yseAe4ZVMM7e7GRFZM6OYWpBKOb++s+SQ8RBIMMe+Bs/CznBMc0QPLjr+vDBxTAkozXsFXQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/huntabyte"
+      ],
+      "dependencies": {
+        "clsx": "^2.1.1",
+        "runed": "^0.35.1",
+        "style-to-object": "^1.0.8"
+      },
+      "engines": {
+        "node": ">=18",
+        "pnpm": ">=8.7.0"
+      },
+      "peerDependencies": {
+        "svelte": "^5.30.2"
+      }
+    },
     "node_modules/svelte-turnstile": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/svelte-turnstile/-/svelte-turnstile-0.11.0.tgz",
@@ -4052,6 +4209,13 @@
       "dependencies": {
         "@types/estree": "^1.0.6"
       }
+    },
+    "node_modules/tabbable": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.3.0.tgz",
+      "integrity": "sha512-EIHvdY5bPLuWForiR/AN2Bxngzpuwn1is4asboytXtpTgsArc+WmSJKVLlhdh71u7jFcryDqB2A8lQvj78MkyQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.14",
@@ -4139,6 +4303,7 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4289,6 +4454,7 @@
       "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "svelte-use-click-outside": "^1.1.0",
         "tslib": "^2.8.1",
         "typescript": "^5.8.3",
+        "typescript-eslint": "^8.47.0",
         "unist-util-visit": "^5.0.0",
         "vite": "^6.3.5"
       }
@@ -1447,17 +1448,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.37.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.37.0.tgz",
-      "integrity": "sha512-jsuVWeIkb6ggzB+wPCsR4e6loj+rM72ohW6IBn2C+5NCvfUVY8s33iFPySSVXqtm5Hu29Ne/9bnA0JmyLmgenA==",
+      "version": "8.47.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.47.0.tgz",
+      "integrity": "sha512-fe0rz9WJQ5t2iaLfdbDc9T80GJy0AeO453q8C3YCilnGozvOyCG5t+EZtg7j7D88+c3FipfP/x+wzGnh1xp8ZA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.37.0",
-        "@typescript-eslint/type-utils": "8.37.0",
-        "@typescript-eslint/utils": "8.37.0",
-        "@typescript-eslint/visitor-keys": "8.37.0",
+        "@typescript-eslint/scope-manager": "8.47.0",
+        "@typescript-eslint/type-utils": "8.47.0",
+        "@typescript-eslint/utils": "8.47.0",
+        "@typescript-eslint/visitor-keys": "8.47.0",
         "graphemer": "^1.4.0",
         "ignore": "^7.0.0",
         "natural-compare": "^1.4.0",
@@ -1471,22 +1472,22 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.37.0",
+        "@typescript-eslint/parser": "^8.47.0",
         "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <5.9.0"
+        "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.37.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.37.0.tgz",
-      "integrity": "sha512-kVIaQE9vrN9RLCQMQ3iyRlVJpTiDUY6woHGb30JDkfJErqrQEmtdWH3gV0PBAfGZgQXoqzXOO0T3K6ioApbbAA==",
+      "version": "8.47.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.47.0.tgz",
+      "integrity": "sha512-lJi3PfxVmo0AkEY93ecfN+r8SofEqZNGByvHAI3GBLrvt1Cw6H5k1IM02nSzu0RfUafr2EvFSw0wAsZgubNplQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.37.0",
-        "@typescript-eslint/types": "8.37.0",
-        "@typescript-eslint/typescript-estree": "8.37.0",
-        "@typescript-eslint/visitor-keys": "8.37.0",
+        "@typescript-eslint/scope-manager": "8.47.0",
+        "@typescript-eslint/types": "8.47.0",
+        "@typescript-eslint/typescript-estree": "8.47.0",
+        "@typescript-eslint/visitor-keys": "8.47.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -1498,18 +1499,18 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <5.9.0"
+        "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.37.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.37.0.tgz",
-      "integrity": "sha512-BIUXYsbkl5A1aJDdYJCBAo8rCEbAvdquQ8AnLb6z5Lp1u3x5PNgSSx9A/zqYc++Xnr/0DVpls8iQ2cJs/izTXA==",
+      "version": "8.47.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.47.0.tgz",
+      "integrity": "sha512-2X4BX8hUeB5JcA1TQJ7GjcgulXQ+5UkNb0DL8gHsHUHdFoiCTJoYLTpib3LtSDPZsRET5ygN4qqIWrHyYIKERA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.37.0",
-        "@typescript-eslint/types": "^8.37.0",
+        "@typescript-eslint/tsconfig-utils": "^8.47.0",
+        "@typescript-eslint/types": "^8.47.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -1520,18 +1521,18 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <5.9.0"
+        "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.37.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.37.0.tgz",
-      "integrity": "sha512-0vGq0yiU1gbjKob2q691ybTg9JX6ShiVXAAfm2jGf3q0hdP6/BruaFjL/ManAR/lj05AvYCH+5bbVo0VtzmjOA==",
+      "version": "8.47.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.47.0.tgz",
+      "integrity": "sha512-a0TTJk4HXMkfpFkL9/WaGTNuv7JWfFTQFJd6zS9dVAjKsojmv9HT55xzbEpnZoY+VUb+YXLMp+ihMLz/UlZfDg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.37.0",
-        "@typescript-eslint/visitor-keys": "8.37.0"
+        "@typescript-eslint/types": "8.47.0",
+        "@typescript-eslint/visitor-keys": "8.47.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1542,9 +1543,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.37.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.37.0.tgz",
-      "integrity": "sha512-1/YHvAVTimMM9mmlPvTec9NP4bobA1RkDbMydxG8omqwJJLEW/Iy2C4adsAESIXU3WGLXFHSZUU+C9EoFWl4Zg==",
+      "version": "8.47.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.47.0.tgz",
+      "integrity": "sha512-ybUAvjy4ZCL11uryalkKxuT3w3sXJAuWhOoGS3T/Wu+iUu1tGJmk5ytSY8gbdACNARmcYEB0COksD2j6hfGK2g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1555,19 +1556,19 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <5.9.0"
+        "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.37.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.37.0.tgz",
-      "integrity": "sha512-SPkXWIkVZxhgwSwVq9rqj/4VFo7MnWwVaRNznfQDc/xPYHjXnPfLWn+4L6FF1cAz6e7dsqBeMawgl7QjUMj4Ow==",
+      "version": "8.47.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.47.0.tgz",
+      "integrity": "sha512-QC9RiCmZ2HmIdCEvhd1aJELBlD93ErziOXXlHEZyuBo3tBiAZieya0HLIxp+DoDWlsQqDawyKuNEhORyku+P8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.37.0",
-        "@typescript-eslint/typescript-estree": "8.37.0",
-        "@typescript-eslint/utils": "8.37.0",
+        "@typescript-eslint/types": "8.47.0",
+        "@typescript-eslint/typescript-estree": "8.47.0",
+        "@typescript-eslint/utils": "8.47.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^2.1.0"
       },
@@ -1580,13 +1581,13 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <5.9.0"
+        "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.37.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.37.0.tgz",
-      "integrity": "sha512-ax0nv7PUF9NOVPs+lmQ7yIE7IQmAf8LGcXbMvHX5Gm+YJUYNAl340XkGnrimxZ0elXyoQJuN5sbg6C4evKA4SQ==",
+      "version": "8.47.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.47.0.tgz",
+      "integrity": "sha512-nHAE6bMKsizhA2uuYZbEbmp5z2UpffNrPEqiKIeN7VsV6UY/roxanWfoRrf6x/k9+Obf+GQdkm0nPU+vnMXo9A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1598,16 +1599,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.37.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.37.0.tgz",
-      "integrity": "sha512-zuWDMDuzMRbQOM+bHyU4/slw27bAUEcKSKKs3hcv2aNnc/tvE/h7w60dwVw8vnal2Pub6RT1T7BI8tFZ1fE+yg==",
+      "version": "8.47.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.47.0.tgz",
+      "integrity": "sha512-k6ti9UepJf5NpzCjH31hQNLHQWupTRPhZ+KFF8WtTuTpy7uHPfeg2NM7cP27aCGajoEplxJDFVCEm9TGPYyiVg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.37.0",
-        "@typescript-eslint/tsconfig-utils": "8.37.0",
-        "@typescript-eslint/types": "8.37.0",
-        "@typescript-eslint/visitor-keys": "8.37.0",
+        "@typescript-eslint/project-service": "8.47.0",
+        "@typescript-eslint/tsconfig-utils": "8.47.0",
+        "@typescript-eslint/types": "8.47.0",
+        "@typescript-eslint/visitor-keys": "8.47.0",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
@@ -1623,20 +1624,20 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <5.9.0"
+        "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.37.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.37.0.tgz",
-      "integrity": "sha512-TSFvkIW6gGjN2p6zbXo20FzCABbyUAuq6tBvNRGsKdsSQ6a7rnV6ADfZ7f4iI3lIiXc4F4WWvtUfDw9CJ9pO5A==",
+      "version": "8.47.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.47.0.tgz",
+      "integrity": "sha512-g7XrNf25iL4TJOiPqatNuaChyqt49a/onq5YsJ9+hXeugK+41LVg7AxikMfM02PC6jbNtZLCJj6AUcQXJS/jGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.7.0",
-        "@typescript-eslint/scope-manager": "8.37.0",
-        "@typescript-eslint/types": "8.37.0",
-        "@typescript-eslint/typescript-estree": "8.37.0"
+        "@typescript-eslint/scope-manager": "8.47.0",
+        "@typescript-eslint/types": "8.47.0",
+        "@typescript-eslint/typescript-estree": "8.47.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1647,17 +1648,17 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <5.9.0"
+        "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.37.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.37.0.tgz",
-      "integrity": "sha512-YzfhzcTnZVPiLfP/oeKtDp2evwvHLMe0LOy7oe+hb9KKIumLNohYS9Hgp1ifwpu42YWxhZE8yieggz6JpqO/1w==",
+      "version": "8.47.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.47.0.tgz",
+      "integrity": "sha512-SIV3/6eftCy1bNzCQoPmbWsRLujS8t5iDIZ4spZOBHqrM+yfX2ogg8Tt3PDTAVKw3sSCiUgg30uOAvK2r9zGjQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.37.0",
+        "@typescript-eslint/types": "8.47.0",
         "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
@@ -4144,6 +4145,30 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.47.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.47.0.tgz",
+      "integrity": "sha512-Lwe8i2XQ3WoMjua/r1PHrCTpkubPYJCAfOurtn+mtTzqB6jNd+14n9UN1bJ4s3F49x9ixAm0FLflB/JzQ57M8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.47.0",
+        "@typescript-eslint/parser": "8.47.0",
+        "@typescript-eslint/typescript-estree": "8.47.0",
+        "@typescript-eslint/utils": "8.47.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "svelte-use-click-outside": "^1.1.0",
     "tslib": "^2.8.1",
     "typescript": "^5.8.3",
+    "typescript-eslint": "^8.47.0",
     "unist-util-visit": "^5.0.0",
     "vite": "^6.3.5"
   },

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     ]
   },
   "devDependencies": {
-    "@jimmyverburgt/svelte-input-otp": "^0.0.3",
     "@paypal/paypal-js": "^8.2.0",
     "@stylistic/eslint-plugin": "^5.2.0",
     "@sveltejs/adapter-node": "^5.2.13",
@@ -28,6 +27,7 @@
     "@types/unist": "^3.0.3",
     "@typescript-eslint/eslint-plugin": "^8.37.0",
     "@typescript-eslint/parser": "^8.37.0",
+    "bits-ui": "^2.14.4",
     "eslint": "^9.31.0",
     "eslint-plugin-svelte": "^3.10.1",
     "globals": "^16.3.0",

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -45,7 +45,7 @@ export function markdown() {
                 }
 
                 if (node.children?.[0]?.value) {
-                    let id = node.children[0].value.toLowerCase().replaceAll(" ", "-")
+                    const id = node.children[0].value.toLowerCase().replaceAll(" ", "-")
                     node.children.splice(0, 0, {
                         type: "link",
                         url: "#" + id,

--- a/src/lib/stats.ts
+++ b/src/lib/stats.ts
@@ -12,7 +12,7 @@ export interface Stats {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export async function fetchStats(fetch: any): Promise<Stats> {
-    let stats = await (await fetch("https://meteorclient.com/api/stats")).json()
+    const stats = await (await fetch("https://meteorclient.com/api/stats")).json()
 
     return {
         builds: stats.builds,

--- a/src/lib/user.ts
+++ b/src/lib/user.ts
@@ -38,7 +38,7 @@ token.subscribe((token) => {
 })
 
 export function refreshUser() {
-    let tok = get(token)
+    const tok = get(token)
 
     if (!tok) {
         user.set(null)

--- a/src/routes/addMcAccount/+page.svelte
+++ b/src/routes/addMcAccount/+page.svelte
@@ -3,7 +3,8 @@
     import { goto } from "$app/navigation"
     import { refreshUser, token } from "$lib/user"
     import Navbar from "$lib/components/navbar.svelte"
-    import { OTPInput, OTPRoot } from "@jimmyverburgt/svelte-input-otp"
+    // noinspection ES6UnusedImports
+    import { PinInput, REGEXP_ONLY_DIGITS } from "bits-ui"
     import { api } from "$lib/api"
 
     $effect(() => {
@@ -13,10 +14,10 @@
     let value = $state<string>("")
     let errorMessage = $state<string>("")
 
-    function onComplete(code: string) {
+    function onComplete() {
         errorMessage = ""
 
-        api("account/mcAccount?code=" + code, true, "POST")
+        api("account/mcAccount?code=" + value, true, "POST")
             .then(() => {
                 refreshUser()
                 goto("/account")
@@ -28,26 +29,33 @@
     }
 </script>
 
-<Navbar />
+<Navbar/>
 
 <div class="container">
     <div>
         <h1>Add MC account</h1>
 
         <ol>
-            <li>Launch your Minecraft client and join our server with the IP <span class="ip">mcauth.meteorclient.com</span></li>
+            <li>Launch your Minecraft client and join our server with the IP <span
+                class="ip">mcauth.meteorclient.com</span></li>
             <li>You will be immediately kicked with a one-time 6-digit code</li>
             <li>Write the code into the input box below</li>
         </ol>
 
-        <OTPRoot maxLength={6} autoFocus={true} inputMode="numeric" {onComplete} bind:value className="otp-root">
-            <OTPInput index={0} className="otp-input" focusClassName="focused" />
-            <OTPInput index={1} className="otp-input" focusClassName="focused" />
-            <OTPInput index={2} className="otp-input" focusClassName="focused" />
-            <OTPInput index={3} className="otp-input" focusClassName="focused" />
-            <OTPInput index={4} className="otp-input" focusClassName="focused" />
-            <OTPInput index={5} className="otp-input" focusClassName="focused" />
-        </OTPRoot>
+        <PinInput.Root bind:value maxlength={6} {onComplete} pattern={REGEXP_ONLY_DIGITS} class="otp-root">
+            {#snippet children({ cells })}
+                {#each cells as cell, i (i)}
+                    <PinInput.Cell {cell} class="otp-input">
+                        {#if cell.char !== null}
+                            <span>{cell.char}</span>
+                        {/if}
+                        {#if cell.hasFakeCaret}
+                            <span class="caret"></span>
+                        {/if}
+                    </PinInput.Cell>
+                {/each}
+            {/snippet}
+        </PinInput.Root>
 
         {#if errorMessage}
             <span class="error">{errorMessage}</span>
@@ -88,22 +96,40 @@
         display: flex;
         justify-content: center;
         gap: 0.25rem;
-
-        color: black;
-        font-size: 2rem;
     }
 
     :global(.otp-input) {
-        width: 1em;
-        height: 1.4em;
-
-        border: 1px rgb(80, 80, 80) solid;
+        position: relative;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 2rem;
+        height: 2.8rem;
+        font-size: 2rem;
+        color: black;
+        border: 1px solid rgb(80, 80, 80);
         border-radius: 0.325rem;
+
+        &[data-active] {
+            border: 2px solid black;
+        }
     }
 
-    :global(.otp-input.focused) {
-        border-width: 2px;
-        border-color: black;
+    :global(.caret) {
+        position: absolute;
+        width: 2px;
+        height: 1.5rem;
+        background-color: black;
+        animation: blink 1s step-end infinite;
+    }
+
+    @keyframes blink {
+        0%, 70%, 100% {
+            opacity: 1;
+        }
+        20%, 50% {
+            opacity: 0;
+        }
     }
 
     .error {

--- a/src/routes/changeEmail/+page.svelte
+++ b/src/routes/changeEmail/+page.svelte
@@ -55,7 +55,6 @@
     </form>
 {/if}
 
-<!-- svelte-ignore css_unused_selector -->
 <style>
     @import "form.css";
 </style>

--- a/src/routes/changePassword/+page.svelte
+++ b/src/routes/changePassword/+page.svelte
@@ -68,7 +68,6 @@
     <button type="submit" class="form-button">Change</button>
 </form>
 
-<!-- svelte-ignore css_unused_selector -->
 <style>
     @import "form.css";
 </style>

--- a/src/routes/changeUsername/+page.svelte
+++ b/src/routes/changeUsername/+page.svelte
@@ -49,7 +49,6 @@
     <button type="submit" class="form-button">Change</button>
 </form>
 
-<!-- svelte-ignore css_unused_selector -->
 <style>
     @import "form.css";
 </style>

--- a/src/routes/forgotPassword/+page.svelte
+++ b/src/routes/forgotPassword/+page.svelte
@@ -47,7 +47,6 @@
     </form>
 {/if}
 
-<!-- svelte-ignore css_unused_selector -->
 <style>
     @import "form.css";
 </style>


### PR DESCRIPTION
This PR improves/simplifies the ESLint config, following the proper order of initialization and improving readability.

It also replaces the long outdated and problematic OTP input component with the headless `bits-ui` one.
This fixes the warnings related to `--legacy-peer-deps` usage. 
A `// noinspection ES6UnusedImports` is added as WebStorm doesn't recognise components dot notation yet ([issue tracker](https://youtrack.jetbrains.com/issue/WEB-63156/Svelte-namespaced-component-imports-are-marked-as-unused)).

`<!-- svelte-ignore css_unused_selector -->` have been removed as they are unnecessary, the warning in the vite  dev console is expected and normal seeing how we import the CSS.

OTP input appears as follows
<img width="730" height="291" alt="image" src="https://github.com/user-attachments/assets/6b59031e-73b9-4624-9feb-1f7f9eb5b9b6" />
